### PR TITLE
Create Gitub Actions workflow to build, check and deploy to PyPI

### DIFF
--- a/.github/workflows/manylinx-build+check+deploy.yaml
+++ b/.github/workflows/manylinx-build+check+deploy.yaml
@@ -1,0 +1,83 @@
+on:
+    push:
+        branches: [ master, testing ]
+
+    pull_request:
+
+name: Build/Check/Deploy to PyPI
+
+jobs:
+    pypi:
+        name: Build on manylinux2014
+        runs-on: ubuntu-18.04
+        strategy:
+            matrix:
+                cfg:
+                    - { python: /opt/python/cp36-cp36m }
+                    - { python: /opt/python/cp37-cp37m }
+                    - { python: /opt/python/cp36-cp38  }
+        container:
+            image: quay.io/pypa/manylinux2014_x86_64:latest
+        steps:
+            - name: Checkout git repository
+              uses: actions/checkout@v2
+              with:
+                path: _src/
+
+            - name: Fetch tags
+              shell: bash
+              run: |
+                pushd _src
+                git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+                popd
+
+            - name: Prepare VM
+              shell: bash
+              run: |
+                export PATH="${{ cfg.python }}/bin:${PATH}"
+                pip3 install cibuildwheel==0.11.1 doctr matplotlib mpi4py nomkl nose numpy scipy sphinx twine
+                mkdir -p ~/.config/matplotlib
+                cp _src/doc/matplotlibrc ~/.config/matplotlib
+
+            - name: Build and install and run tests
+              env:
+                PYPMC_MPI_NPROC: 1
+              shell: bash
+              run: |
+                export PATH="${{ cfg.python }}/bin:${PATH}"
+                pushd _src
+                export NOSETESTS3=nosetests
+                make install3
+                make check3
+                make check3mpi
+                popd
+
+            - name: Build documentation and deploy
+              env:
+                PYPMC_MPI_NPROC: 1
+              shell: bash
+              run: |
+                export PATH="${{ cfg.python }}/bin:${PATH}"
+                pushd _src
+                make doc
+                doctr deploy . --built-docs doc/_build/
+                popd
+
+            - name: Build wheel and deploy
+              env:
+                PYTHON:         ${{ matrix.cfg.pypath }}/bin/python
+                TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+                TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+              shell: bash
+              run: |
+                pushd _src
+                cibuildwheel --output-dir wheelhouse;
+                # check if this is not a tagged commit, and exit immediatly if true.
+                if ! git describe --abbrev=0 --tags --exact-match HEAD &> /dev/null ; then exit 0 ; fi
+                $PYTHON -m twine upload wheelhouse/*.whl
+
+            - name: Upload wheel as artifact
+              uses: actions/upload-artifact@v1
+              with:
+                name: pypmc-source-manylinux2014-${{ matrix.cfg.pysuffix }}-${{ github.sha }}
+                path: _src/wheelhouse


### PR DESCRIPTION
- Uses the manylinux2014 docker image. I use the same for EOS. Can be changed later to e.g. manylinux2010 or even manylinux1?
- Builds for python3 only. Do we really need python2.x?
- Builds wheel for every commit, but only deploys to PyPI for tagged commits.
- Builds and deploys documentation for every commit. Should this step deploy only on tagged commits?
